### PR TITLE
throw exception when onError trigger & setLoaded after props.onLoad called (if exists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,29 @@ import ImgSuspense from 'img-suspense';
 
 ```
 
-## Exception Handle
+## Handle Exception
+
+```jsx
+<ErrorBoundary>
+  <ImgSuspense src="./path/picuture.jpg" fallback={<p>Pending...</p>} />
+</ErrorBoundary>
+```
 
 If the **img** fails to load (for example, due to network failure), it will trigger an error.
 
 You can handle these errors to show a nice user experience and manage recovery with Error Boundaries.
 
 That's a same way you handle React.suspense exception.
+
 - https://reactjs.org/docs/code-splitting.html#error-boundaries
 - https://reactjs.org/docs/error-boundaries.html
 
-Or you can just **override onError handler** to prevent component exception, treat it like an img element!
+Or...
+```jsx
+<ImgSuspense
+  onError={e => console.log('Error occurs! Override ImgSuspense exception')}
+  src="./path/picuture.jpg"
+  fallback={<p>Pending...</p>}
+/>
+```
+You can just **override onError handler** to prevent component exception, treat it like an img element!

--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ import ImgSuspense from 'img-suspense';
   />
 
 ```
+
+## Exception Handle
+
+If the **img** fails to load (for example, due to network failure), it will trigger an error.
+
+You can handle these errors to show a nice user experience and manage recovery with Error Boundaries.
+
+That's a same way you handle React.suspense exception.
+- https://reactjs.org/docs/code-splitting.html#error-boundaries
+- https://reactjs.org/docs/error-boundaries.html
+
+Or you can just **override onError handler** to prevent component exception, treat it like an img element!

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 /**
  * Flow Description
- * 
+ *
  * onLoad
  * => call prop.onLoad (if callable)
- * => setLoaded 
+ * => setLoaded
  * => render img
- * 
+ *
  * onError
  * => setIsError
  * => Throw Exception
- * 
+ *
  */
 import React, { useState } from 'react';
 import Proptypes from 'prop-types';
@@ -18,7 +18,15 @@ import Proptypes from 'prop-types';
  * Allow user to pass onLoad handler
  * Allow user to override onError handler
  */
-const ImgSuspense = ({ fallback, src, alt, style, onLoad, ...restProps }) => {
+const ImgSuspense = ({
+  fallback,
+  src,
+  alt,
+  style,
+  onLoad,
+  onError,
+  ...restProps
+}) => {
   const [isLoaded, setLoaded] = useState(false);
   const [isError, setIsError] = useState(false);
   if (isError) throw new Error('img onerror');
@@ -30,9 +38,14 @@ const ImgSuspense = ({ fallback, src, alt, style, onLoad, ...restProps }) => {
         style={isLoaded ? style : { display: 'none' }}
         onLoad={() => {
           typeof onLoad === 'function' && onLoad();
+          // If onLoad exists, call it.
+
           setLoaded(true);
         }}
-        onError={() => setIsError(true)}
+        onError={
+          () => (typeof onError === 'function' ? onError() : setIsError(true))
+          // If onError exists, call it and should not throw exception.
+        }
         {...restProps}
       />
       {!isLoaded && fallback}
@@ -41,6 +54,8 @@ const ImgSuspense = ({ fallback, src, alt, style, onLoad, ...restProps }) => {
 };
 ImgSuspense.propTypes = {
   src: Proptypes.string.isRequired,
-  fallback: Proptypes.element.isRequired
+  fallback: Proptypes.element.isRequired,
+  onLoad: Proptypes.func,
+  onError: Proptypes.func
 };
 export default ImgSuspense;

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,39 @@
+/**
+ * Flow Description
+ * 
+ * onLoad
+ * => call prop.onLoad (if callable)
+ * => setLoaded 
+ * => render img
+ * 
+ * onError
+ * => setIsError
+ * => Throw Exception
+ * 
+ */
 import React, { useState } from 'react';
 import Proptypes from 'prop-types';
-const ImgSuspense = ({ fallback, src, alt, style, ...restProps }) => {
+
+/**
+ * Allow user to pass onLoad handler
+ * Allow user to override onError handler
+ */
+const ImgSuspense = ({ fallback, src, alt, style, onLoad, ...restProps }) => {
   const [isLoaded, setLoaded] = useState(false);
+  const [isError, setIsError] = useState(false);
+  if (isError) throw new Error('img onerror');
   return (
     <React.Fragment>
       <img
         src={src}
         alt={alt}
+        style={isLoaded ? style : { display: 'none' }}
+        onLoad={() => {
+          typeof onLoad === 'function' && onLoad();
+          setLoaded(true);
+        }}
+        onError={() => setIsError(true)}
         {...restProps}
-        style={isLoaded ? style : Object.assign({}, style, { display: 'none' })}
-        onLoad={() => setLoaded(true)}
       />
       {!isLoaded && fallback}
     </React.Fragment>


### PR DESCRIPTION
Throw exception when onError like React.suspense. 
But allow to override onError.

### Why to throw exception? 
Cause we can use ErrorBoundary to catch Suspense exception
```jsx
<ErrorBoundary>
  <ImgSuspense 
    src="./path/picuture.jpg" 
    fallback={<p>Pending...</p>} 
  />
</ErrorBoundary>
```
https://reactjs.org/docs/code-splitting.html#error-boundaries

### Why to allow use override this?
Cause we could make user feel like `<ImgSuspense />` is `<img />`
```jsx
<ImgSuspense 
  src="/path/pic.png" 
  onError={ ()=>console.log("Error trigger!") } 
  onLoad={ ()=>console.log("Load!")} 
  fallback={<p>Pending...</p>}
/>
```
It will be transformed to 
```jsx
<img 
  src="/path/pic.png" 
  onError={ ()=>console.log("Error trigger!") } 
  onLoad={ ()=>console.log("Load!")} 
/>
```
